### PR TITLE
Add Newton to Canadian Exchanges

### DIFF
--- a/_templates/exchanges.html
+++ b/_templates/exchanges.html
@@ -254,6 +254,8 @@ id: exchanges
           <a class="marketplace-link" href="https://www.coinsmart.com/">Coinsmart</a>
           <br>
           <a class="marketplace-link" href="https://shakepay.co/">Shakepay</a>
+          <br>
+          <a class="marketplace-link" href="https://www.newton.co/">Newton</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Newton is Canada's first no-fee cryptocurrency exchange: https://www.newton.co/. 
Here's a list of pricing that includes BTC: https://www.newton.co/prices.html.